### PR TITLE
Fix gem versioning for react-rails to not use React 16 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,4 +34,4 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'responders'
-gem 'react-rails'
+gem 'react-rails', '2.3.1'


### PR DESCRIPTION
Currently the tutorial page and this repository doesn't use the react 15 version of react-rails which is 2.3.1 (which the tutorial was written for) Not specifying the version causes it to use the latest gem version which includes syntax changes and deprecations from react 16.